### PR TITLE
Fixed next() call

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "debug": "node register",
         "build": "babel src -d dist",
-        "prepublish": "npm run build -s",
+        "prepare": "npm run build -s",
         "patch": "npm version patch && npm publish",
         "minor": "npm version minor && npm publish",
         "major": "npm version major && npm publish",

--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,8 @@ export function getHandler(i18next, options = {}) {
         if (!req.lng) {
             await next();
         } else {
-            await i18next.loadLanguages(req.lng, async function() {
-                await next();
-            });
+            await i18next.loadLanguages(req.lng);
+            await next();
         }
     };
 }


### PR DESCRIPTION
Middleware returns promise for `i18next.loadLanguages()` - this is wrong behavior.
In my case, this causes a bug when the server does not call `next()` and returns an empty body.